### PR TITLE
Logs sur une seule ligne

### DIFF
--- a/src/Scheduler.js
+++ b/src/Scheduler.js
@@ -65,8 +65,7 @@ export default class Scheduler {
       const runningApps = await registry.listApps();
       if (runningApps) {
         console.log(
-          'Active apps: ',
-          runningApps.map((app) => app.name)
+          JSON.stringify({ active_apps: runningApps.map((app) => app.name) })
         );
       }
     } catch (err) {

--- a/src/provider/PaasProvider.js
+++ b/src/provider/PaasProvider.js
@@ -69,10 +69,10 @@ export default class PaasProvider {
               shell: true,
             });
             afterAppStart.stdout.on('data', (data) => {
-              console.log(`stdout: ${data}`);
+              console.log({ event: 'after_app_start', appId, stdout: data });
             });
             afterAppStart.stderr.on('data', (data) => {
-              console.error(`stderr: ${data}`);
+              console.error({ event: 'after_app_start', appId, stderr: data });
             });
             afterAppStart.on('close', async (code) => {
               return resolve();
@@ -92,10 +92,10 @@ export default class PaasProvider {
           shell: true,
         });
         beforeAppStart.stdout.on('data', (data) => {
-          console.log(`stdout: ${data}`);
+          console.log({ event: 'before_app_start', appId, stdout: data });
         });
         beforeAppStart.stderr.on('data', (data) => {
-          console.error(`stderr: ${data}`);
+          console.log({ event: 'before_app_start', appId, stderr: data });
         });
         beforeAppStart.on('close', (code) => {
           executeStartApp(resolve, reject);
@@ -124,10 +124,10 @@ export default class PaasProvider {
       if (config.hooks.afterAppStop) {
         const afterAppStop = spawn(config.hooks.afterAppStop, { shell: true });
         afterAppStop.stdout.on('data', (data) => {
-          console.log(`stdout: ${data}`);
+          console.log({ event: 'after_app_stop', appId, stdout: data });
         });
         afterAppStop.stderr.on('data', (data) => {
-          console.error(`stderr: ${data}`);
+          console.log({ event: 'after_app_stop', appId, stderr: data });
         });
         afterAppStop.on('close', async (code) => {
           return resolve();
@@ -142,10 +142,10 @@ export default class PaasProvider {
           shell: true,
         });
         beforeAppStop.stdout.on('data', (data) => {
-          console.log(`stdout: ${data}`);
+          console.log({ event: 'before_app_stop', appId, stdout: data });
         });
         beforeAppStop.stderr.on('data', (data) => {
-          console.error(`stderr: ${data}`);
+          console.log({ event: 'before_app_stop', appId, stderr: data });
         });
         beforeAppStop.on('close', (code) => {
           executeStopApp(resolve, reject);

--- a/src/redis.js
+++ b/src/redis.js
@@ -12,7 +12,7 @@ if (config.registry.type === 'redis') {
     });
 
     client.on('error', (err) => {
-      console.log('Redis Client Error', err);
+      console.log(JSON.stringify({ msg: 'Redis Client Error', err: err.stack }));
     });
 
     client.on('ready', () => {


### PR DESCRIPTION
## :wrench: Problem

Les journaux de Paastis sont souvent sur plusieurs lignes, ce qui les rend difficiles à analyser.

## :cake: Solution

On remplace plusieurs `console.log(…)` par `console.log(JSON.stringify(…))`. Tous les logs
ne sont pas convertis en JSON, seulement ceux qui sont susceptibles de générer plusieurs lignes.

La bonne solution serait de mettre en place un logger comme `pino` par exemple.

